### PR TITLE
applyFilter works on local collection

### DIFF
--- a/spec/core/collection_spec.coffee
+++ b/spec/core/collection_spec.coffee
@@ -36,6 +36,18 @@ describe "Luca.Collection", ->
 
     expect( registerSpy ).toHaveBeenCalled()
 
+  it "should query collection with filter", ->
+    models = []
+    models.push id: i, key: 'value' for i in [0..9]
+    models[3].key = 'specialValue'
+
+    collection = new Luca.Collection models
+
+    collection.applyFilter key: 'specialValue'
+
+    expect(collection.length).toBe 1
+    expect(collection.first().get('key')).toBe 'specialValue'
+
 describe "The ifLoaded helper", ->
   it "should fire the passed callback automatically if there are models", ->
     spy = sinon.spy()

--- a/src/core/collection.coffee
+++ b/src/core/collection.coffee
@@ -135,8 +135,11 @@ Luca.Collection = (Backbone.QueryCollection || Backbone.Collection).extend
   # options hash will pass these options to the call to @fetch()
   # setting refresh to true, forcing a remote call to the REST API
   applyFilter: (filter={}, options={})->
-    @applyParams(filter)
-    @fetch _.extend(options,refresh:true)
+    if options.remote? is true
+      @applyParams(filter)
+      @fetch _.extend(options,refresh:true)
+    else
+      @reset @query filter
 
   # You can apply params to a collection, so that any upcoming requests
   # made to the REST API are made with the key values specified

--- a/vendor/assets/javascripts/luca-ui-base.js
+++ b/vendor/assets/javascripts/luca-ui-base.js
@@ -598,10 +598,14 @@
     applyFilter: function(filter, options) {
       if (filter == null) filter = {};
       if (options == null) options = {};
-      this.applyParams(filter);
-      return this.fetch(_.extend(options, {
-        refresh: true
-      }));
+      if ((options.remote != null) === true) {
+        this.applyParams(filter);
+        return this.fetch(_.extend(options, {
+          refresh: true
+        }));
+      } else {
+        return this.reset(this.query(filter));
+      }
     },
     applyParams: function(params) {
       this.base_params || (this.base_params = _(Luca.Collection.baseParams()).clone());

--- a/vendor/assets/javascripts/luca-ui-spec.js
+++ b/vendor/assets/javascripts/luca-ui-spec.js
@@ -598,10 +598,14 @@
     applyFilter: function(filter, options) {
       if (filter == null) filter = {};
       if (options == null) options = {};
-      this.applyParams(filter);
-      return this.fetch(_.extend(options, {
-        refresh: true
-      }));
+      if ((options.remote != null) === true) {
+        this.applyParams(filter);
+        return this.fetch(_.extend(options, {
+          refresh: true
+        }));
+      } else {
+        return this.reset(this.query(filter));
+      }
     },
     applyParams: function(params) {
       this.base_params || (this.base_params = _(Luca.Collection.baseParams()).clone());
@@ -3212,7 +3216,7 @@
       this.server.respond();
       return expect(collection.length).toEqual(2);
     });
-    return it("should attempt to register with a collection manager", function() {
+    it("should attempt to register with a collection manager", function() {
       var collection, registerSpy;
       registerSpy = sinon.spy();
       collection = new Luca.Collection([], {
@@ -3220,6 +3224,23 @@
         register: registerSpy
       });
       return expect(registerSpy).toHaveBeenCalled();
+    });
+    return it("should query collection with filter", function() {
+      var collection, i, models;
+      models = [];
+      for (i = 0; i <= 9; i++) {
+        models.push({
+          id: i,
+          key: 'value'
+        });
+      }
+      models[3].key = 'specialValue';
+      collection = new Luca.Collection(models);
+      collection.applyFilter({
+        key: 'specialValue'
+      });
+      expect(collection.length).toBe(1);
+      return expect(collection.first().get('key')).toBe('specialValue');
     });
   });
 

--- a/vendor/assets/javascripts/luca-ui.js
+++ b/vendor/assets/javascripts/luca-ui.js
@@ -598,10 +598,14 @@
     applyFilter: function(filter, options) {
       if (filter == null) filter = {};
       if (options == null) options = {};
-      this.applyParams(filter);
-      return this.fetch(_.extend(options, {
-        refresh: true
-      }));
+      if ((options.remote != null) === true) {
+        this.applyParams(filter);
+        return this.fetch(_.extend(options, {
+          refresh: true
+        }));
+      } else {
+        return this.reset(this.query(filter));
+      }
     },
     applyParams: function(params) {
       this.base_params || (this.base_params = _(Luca.Collection.baseParams()).clone());


### PR DESCRIPTION
applyFilter now uses backbone.query to filter collections, instead of making a request to the server. passing remote: true object will revert to old behavior and make the request to the server.
