### PR TITLE
Fix for resetting filters on collection_view component

### DIFF
--- a/app/assets/javascripts/luca/concerns/filterable.coffee
+++ b/app/assets/javascripts/luca/concerns/filterable.coffee
@@ -73,7 +73,6 @@ Luca.concerns.Filterable =
 
   applyFilter: (query={}, options={})->
     options = _.defaults(options, @getQueryOptions())
-    query = _.defaults(query, @getQuery())
     @getFilterState().clear(silent: true)
     @getFilterState().set({query,options}, options)
 


### PR DESCRIPTION
When applying new filters with a field which was not on the previous filter, this old filter gets merged into the new ones.

First filter:
`{ a: 'a' }`
Result of first filter:
`{ a: 'a' }`

Second filter:
`{ b: 'b' }`
Result of second filter:
`{ a: 'a', b: 'b' }`

This pull request partially fixes the problem, since the previous query gets stored on `@query` and merged with the new ones. The clients using it will still need to reset `@query` before filtering.. 
